### PR TITLE
Fix documentation deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,8 +18,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.9"
 
@@ -28,8 +28,10 @@ jobs:
       # ADJUST THIS: build your documentation into docs/.
       # We use a custom build script for pdoc itself, ideally you just run `pdoc -o docs/ ...` here.
       - run: pdoc -o docs --docformat google --logo https://user-images.githubusercontent.com/37182127/233436178-26c2b4be-e630-4f9b-b4c9-d58424bd365d.png todonotifier/
+      # Add this step to create .nojekyll file
+      - run: touch docs/.nojekyll
 
-      - uses: actions/upload-pages-artifact@v1
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: docs/
 
@@ -46,4 +48,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 
 **Automated TODO tracking and notifications for your codebase**
 
-Never forget a TODO again! Automatically parse, track, and get notified about TODO items in your code.
+Never forget a TODO again! Automatically parse, track, and get notified about TODO items
+in your code.
 
 [Installation](#installation) •
 [Quick Start](#quick-start) •
@@ -24,7 +25,8 @@ src="https://github.com/ashu-tosh-kumar/todo_notifier/assets/37182127/73f4b642-f
 
 ## Features
 
-- **Smart TODO Detection** - Automatically discovers TODO items across your entire codebase
+- **Smart TODO Detection** - Automatically discovers TODO items across your entire
+  codebase
 - **Date-based Tracking** - Set completion dates and get notified about overdue items
 - **User Assignment** - Assign TODOs to specific team members
 - **Multiple Report Types** - Module-wise, user-wise, and deadline-based summaries
@@ -211,7 +213,8 @@ TODO Notifier supports a flexible format for TODO items in your code:
 - `message` - Optional description
 
 **Supported Languages:**
-Works with any programming language that supports comments (Python, JavaScript, Java, C++, etc.)
+Works with any programming language that supports comments (Python, JavaScript, Java,
+C++, etc.)
 
 ## 🔧 Architecture
 
@@ -351,13 +354,15 @@ pytest tests
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for
+details.
 
 ## Links
 
 - [PyPI Package](https://pypi.org/project/todonotifier/)
 - [Documentation](https://ashu-tosh-kumar.github.io/todo_notifier/)
-- [Setup Guide](https://medium.com/@at-k/streamline-your-todos-with-todo-notifier-for-python-projects-6f95c03a2d34)
+- [Setup
+  Guide](https://medium.com/@at-k/streamline-your-todos-with-todo-notifier-for-python-projects-6f95c03a2d34)
 - [Issue Tracker](https://github.com/ashu-tosh-kumar/todo_notifier/issues)
 
 ## Changelog

--- a/README.md
+++ b/README.md
@@ -22,24 +22,25 @@ src="https://github.com/ashu-tosh-kumar/todo_notifier/assets/37182127/73f4b642-f
 
 </div>
 
-## ✨ Features
+## Features
 
-- 🔍 **Smart TODO Detection** - Automatically discovers TODO items across your entire codebase
-- 📅 **Date-based Tracking** - Set completion dates and get notified about overdue items
-- 👥 **User Assignment** - Assign TODOs to specific team members
-- 📊 **Multiple Report Types** - Module-wise, user-wise, and deadline-based summaries
-- 📧 **Email Notifications** - Automated email reports with HTML formatting
-- 🎯 **Flexible Configuration** - Extensive customization options for different workflows
-- 🚀 **Multiple Integration Methods** - Works with Git repositories, local directories, or single files
-- 📈 **Export Options** - Save reports as HTML files for sharing and archiving
+- **Smart TODO Detection** - Automatically discovers TODO items across your entire codebase
+- **Date-based Tracking** - Set completion dates and get notified about overdue items
+- **User Assignment** - Assign TODOs to specific team members
+- **Multiple Report Types** - Module-wise, user-wise, and deadline-based summaries
+- **Email Notifications** - Automated email reports with HTML formatting
+- **Flexible Configuration** - Extensive customization options for different workflows
+- **Multiple Integration Methods** - Works with Git repositories, local directories, or
+  single files
+- **Export Options** - Save reports as HTML files for sharing and archiving
 
-## 📦 Installation
+## Installation
 
 ```bash
 pip install todonotifier
 ```
 
-## 🚀 Quick Start
+## Quick Start
 
 ### Basic Usage
 
@@ -91,7 +92,7 @@ config = DefaultConfig(
 )
 ```
 
-### 📋 Examples
+### Examples
 
 #### Local Directory Scanning
 
@@ -148,7 +149,7 @@ config = DefaultConfig(
 )
 ```
 
-## 📊 Generated Reports
+## Generated Reports
 
 TODO Notifier generates three types of reports as `.html` files by default if
 `save_html_reports=True` was set in configuration. All reports generated are stored in
@@ -184,7 +185,7 @@ for generator in summary_generators:
 - **Email**: Automatically sent when `notifier` is configured
 - **Programmatic Access**: Available through summary generator objects
 
-## 📝 TODO Format
+## TODO Format
 
 TODO Notifier supports a flexible format for TODO items in your code:
 
@@ -229,7 +230,7 @@ Works with any programming language that supports comments (Python, JavaScript, 
 - **Summary Generators**: Pluggable report generators with HTML output
 - **Notification System**: Extensible notification framework (Email included)
 
-## 🛠️ Customization
+## Customization
 
 ### Custom Summary Generators
 
@@ -309,7 +310,7 @@ class CustomConfig(BaseConfig):
         # Further Custom configuration code
 ```
 
-## 🤝 Contributing
+## Contributing
 
 We welcome contributions! Here's how you can help:
 
@@ -336,10 +337,10 @@ pytest tests
 
 ### Ways to Contribute
 
-- 🐛 **Bug Reports**: Open an issue with details and reproduction steps
-- 💡 **Feature Requests**: Suggest new features or improvements
-- 📝 **Documentation**: Improve docs, examples, or tutorials
-- 🔧 **Code**: Submit pull requests for bug fixes or features
+- **Bug Reports**: Open an issue with details and reproduction steps
+- **Feature Requests**: Suggest new features or improvements
+- **Documentation**: Improve docs, examples, or tutorials
+- **Code**: Submit pull requests for bug fixes or features
 
 ### Guidelines
 
@@ -348,36 +349,36 @@ pytest tests
 - Update documentation for new features
 - Keep commits focused and descriptive
 
-## 📄 License
+## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
-## 🔗 Links
+## Links
 
-- 📦 [PyPI Package](https://pypi.org/project/todonotifier/)
-- 📚 [Documentation](https://ashu-tosh-kumar.github.io/todo_notifier/)
-- 📖 [Setup Guide](https://medium.com/@at-k/streamline-your-todos-with-todo-notifier-for-python-projects-6f95c03a2d34)
-- 🐛 [Issue Tracker](https://github.com/ashu-tosh-kumar/todo_notifier/issues)
+- [PyPI Package](https://pypi.org/project/todonotifier/)
+- [Documentation](https://ashu-tosh-kumar.github.io/todo_notifier/)
+- [Setup Guide](https://medium.com/@at-k/streamline-your-todos-with-todo-notifier-for-python-projects-6f95c03a2d34)
+- [Issue Tracker](https://github.com/ashu-tosh-kumar/todo_notifier/issues)
 
-## 📈 Changelog
+## Changelog
 
 ### v1.4.0 (Latest)
 
-- ⚠️ **Breaking Change**: Renamed `CONNECT_METHOD` in in `todonotifier.connect` to
+- **Breaking Change**: Renamed `CONNECT_METHOD` in in `todonotifier.connect` to
   `ConnectMethod`.
-- ♿ Added accessibility captions to HTML reports
-- 🔒 Security improvements and package upgrades
-- 🧹 Code quality improvements
+- Added accessibility captions to HTML reports
+- Security improvements and package upgrades
+- Code quality improvements
 
 ### v1.3.2
 
-- 🐍 Updated minimum Python version to 3.9+
-- 📦 Migrated from setup.py to Poetry
-- 🔄 Package dependency updates
+- Updated minimum Python version to 3.9+
+- Migrated from setup.py to Poetry
+- Package dependency updates
 
 ### v1.3.1
 
-- 🐛 Critical bug fixes (recommended minimum version)
+- Critical bug fixes (recommended minimum version)
 
 ### <v1.3.1
 

--- a/todonotifier/__init__.py
+++ b/todonotifier/__init__.py
@@ -1,0 +1,106 @@
+"""
+TODO Notifier - Automated TODO tracking and notifications for your codebase
+
+Never forget a TODO again! Automatically parse, track, and get notified about TODO items
+in your code.
+
+## Features
+
+- **Smart TODO Detection** - Automatically discovers TODO items across your entire
+  codebase
+- **Date-based Tracking** - Set completion dates and get notified about overdue items
+- **User Assignment** - Assign TODOs to specific team members
+- **Multiple Report Types** - Module-wise, user-wise, and deadline-based summaries
+- **Email Notifications** - Automated email reports with HTML formatting
+- **Flexible Configuration** - Extensive customization options for different workflows
+- **Multiple Integration Methods** - Works with Git repositories, local directories, or
+  single files
+- **Export Options** - Save reports as HTML files for sharing and archiving
+
+## Quick Start
+
+```python
+from todonotifier.config import DefaultConfig
+from todonotifier.connect import ConnectMethod, Connect
+from todonotifier.driver import run as driver_run
+
+# Configure for a Git repository
+git_url = "https://github.com/your-username/your-repo.git"
+project_name = "your-project"
+
+connect = Connect(
+    connect_method=ConnectMethod.GIT_CLONE,
+    project_dir_name=project_name,
+    url=git_url,
+    branch_name="main"
+)
+
+config = DefaultConfig(
+    save_html_reports=True,
+    ignore_todo_case=True
+)
+
+# Generate TODO reports
+driver_run(connect=connect, config=config)
+```
+
+## TODO Format
+
+TODO Notifier supports a flexible format for TODO items:
+
+```python
+# Full format with all components
+# TODO {2024-12-31} @john_doe Implement user authentication
+
+# Date only
+# TODO {2024-12-31} Add error handling
+
+# User only
+# TODO @jane_smith Review this logic
+
+# Simple TODO
+# TODO Fix this bug
+```
+
+**Format Components:**
+- `TODO` - The keyword (case-insensitive option available)
+- `{YYYY-MM-DD}` - Optional completion date
+- `@username` - Optional assignee
+- `message` - Optional description
+
+## Architecture
+
+The system consists of several key components:
+
+- **todo_notifier.py** - Main parsing logic that extracts TODO items using regex
+  patterns
+- **models.py** - Core data models (`TODO`, `USER`, `POSITION`) with date parsing and
+  validation
+- **config.py** - Configuration system with `BaseConfig` and `DefaultConfig` classes
+- **driver.py** - Main orchestration layer that coordinates parsing, summary generation,
+  and notifications
+- **connect.py** - Repository connection handlers for git repos, local directories, and
+  files
+- **summary_generators.py** - Pluggable summary generators (by module, expired TODOs,
+  upcoming TODOs)
+- **notifier.py** - Notification system with email support and extensible base classes
+
+## Generated Reports
+
+TODO Notifier generates three types of reports by default:
+
+1. **Module-wise Summary** - Lists all TODO items organized by file/module
+2. **Expired TODOs by User** - Highlights overdue TODO items assigned to each team
+   member
+3. **Upcoming Week TODOs** - Shows TODO items due within the next 7 days
+
+All reports can be saved as HTML files and/or sent via email notifications.
+
+## Installation
+
+```bash
+pip install todonotifier
+```
+
+For more examples and advanced usage, see the individual module documentation.
+"""


### PR DESCRIPTION
- Updated to `README.md` to remove icons and fix intra page links.
- Try fixing documentation build failure by upgrading action versions and adding `.nojekyll` file to documentation artifact.
- Added some info to `todonotifier/__init__.py` to provide some basic info on pdoc documentation home page.